### PR TITLE
Fix pipeline import in Flow Analyzer

### DIFF
--- a/apps/flow-analyzer/FlowAnalyzerApp.html
+++ b/apps/flow-analyzer/FlowAnalyzerApp.html
@@ -5,9 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Power Automate Doc Generator</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
-    <script type="module">
-        import { pipeline } from 'https://cdn.jsdelivr.net/npm/@xenova/transformers@1.3.0';
-        window.loadGenerator = async () => pipeline('text-generation', 'Xenova/distilgpt2');
+    <script src="https://cdn.jsdelivr.net/npm/@xenova/transformers@1.3.0/dist/transformers.min.js"></script>
+    <script>
+        window.loadGenerator = async () =>
+            pipeline('text-generation', 'Xenova/distilgpt2', { dtype: 'fp16' });
     </script>
     <style>
         body {


### PR DESCRIPTION
## Summary
- update FlowAnalyzerApp to request fp16 model instead of default quantized version

## Testing
- `npm test` *(fails: could not find package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6842b9c0ea9c833095bd4d249a935639